### PR TITLE
DELETE requests don't have a request body but headers are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
 # Postgrestex
 
 **Status: POC**
-
 
 Elixir Postgrestex library for Postgrest. The design mirrors that of [postgrest-py](https://github.com/supabase/postgrest-py)
 
@@ -19,7 +17,6 @@ def deps do
 end
 ```
 
-
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/postgrestex](https://hexdocs.pm/postgrestex).
@@ -33,6 +30,7 @@ First, `import Postgrestex`
 Then do any one of the following options:
 
 ### Create
+
 Example usage:
 
 ```
@@ -42,10 +40,11 @@ init("public") \
         %{username: "nevergonna", age_range: "[1,2)", status: "ONLINE", catchphrase: "giveyouup"},
         false
       ) \
-      |> call() 
+      |> call()
 ```
 
 ### Read
+
 Example usage:
 
 ```
@@ -56,6 +55,7 @@ init("public") \
 ```
 
 ### Update
+
 Example usage:
 
 ```
@@ -67,18 +67,18 @@ Example usage:
 ```
 
 ### Delete
+
 Example usage:
 
 ```
 init("public") \
   |> from("users") \
   |> eq("username", "nevergonna") \
-  |> delete(%{status: "ONLINE"}) \
+  |> eq("status", "ONLINE") \
+  |> delete() \
   |> call()
 ```
 
 ## Testing
 
 Run `mix test`
-
-

--- a/lib/postgrestex.ex
+++ b/lib/postgrestex.ex
@@ -91,7 +91,7 @@ defmodule Postgrestex do
         "POST" -> HTTPoison.post(url, body, headers, params: params, options: options)
         "GET" -> HTTPoison.get(url, headers, params: params, options: options)
         "PATCH" -> HTTPoison.patch(url, body, headers, params: params, options: options)
-        "DELETE" -> HTTPoison.delete(url, [], params: params, options: options)
+        "DELETE" -> HTTPoison.delete(url, headers, params: params, options: options)
       end
     end)
     |> Task.await()
@@ -122,7 +122,7 @@ defmodule Postgrestex do
           HTTPoison.patch!(url, body, headers, params: params, options: options)
 
         "DELETE" ->
-          HTTPoison.delete!(url, [], params: params, options: options)
+          HTTPoison.delete!(url, headers, params: params, options: options)
 
         _ ->
           raise NoMethodException
@@ -161,9 +161,9 @@ defmodule Postgrestex do
   Delete an existing value in the currently selected table.
   """
   @doc since: "0.1.0"
-  @spec delete(map(), map()) :: map()
-  def delete(req, json) do
-    req |> Map.merge(%{method: "DELETE", body: json})
+  @spec delete(map()) :: map()
+  def delete(req) do
+    req |> Map.merge(%{method: "DELETE"})
   end
 
   @spec order(map(), String.t(), true | false, true | false) :: map()

--- a/test/postgrestex_test.exs
+++ b/test/postgrestex_test.exs
@@ -56,7 +56,8 @@ defmodule PostgrestexTest do
       init("public")
       |> from("users")
       |> eq("username", "awailas")
-      |> delete(%{status: "ONLINE"})
+      |> eq("status", "ONLINE")
+      |> delete()
       |> call()
 
     assert(resp.status_code == 204)


### PR DESCRIPTION
Fixes `DELETE` requests since now headers are passed and not an empty list.
Also doesn't expect a `body` anymore, which got ignored in the end anyway.