### PR TITLE
Fixes and extensions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1.7
         with:
           otp-version: '22.2'
           elixir-version: '1.11'

--- a/lib/postgrestex.ex
+++ b/lib/postgrestex.ex
@@ -140,7 +140,7 @@ defmodule Postgrestex do
   Insert a row into currently selected table. Does an insert and update if upsert is set to True
   """
   @doc since: "0.1.0"
-  @spec insert(map(), list(), true | false) :: map()
+  @spec insert(map(), map(), true | false) :: map()
   def insert(req, json, upsert \\ false) do
     prefer_option = if upsert, do: ",resolution=merge-duplicates", else: ""
     headers = update_headers(req, %{Prefer: prefer_option})

--- a/lib/postgrestex.ex
+++ b/lib/postgrestex.ex
@@ -133,7 +133,7 @@ defmodule Postgrestex do
 
   @spec select(map(), list()) :: map()
   def select(req, columns) do
-    update_headers(req, %{select: Enum.join(columns, ","), method: "GET"})
+    %{req | params: [{:select, Enum.join(columns, ",")} | req.params], method: "GET"}
   end
 
   @doc """

--- a/lib/postgrestex.ex
+++ b/lib/postgrestex.ex
@@ -161,9 +161,10 @@ defmodule Postgrestex do
   Delete an existing value in the currently selected table.
   """
   @doc since: "0.1.0"
-  @spec delete(map()) :: map()
-  def delete(req) do
-    req |> Map.merge(%{method: "DELETE"})
+  @spec delete(map(), keyword()) :: map()
+  def delete(req, options \\ []) do
+    apply_returning(req, options)
+    |> Map.merge(%{method: "DELETE"})
   end
 
   @spec order(map(), String.t(), true | false, true | false) :: map()
@@ -344,5 +345,13 @@ defmodule Postgrestex do
   @spec update_headers(map(), map()) :: map()
   def update_headers(req, updates) do
     Kernel.update_in(req.headers, &Map.merge(&1, updates))
+  end
+
+  defp apply_returning(req, options) do
+    if Keyword.get(options, :returning) do
+      update_headers(req, %{Prefer: "return=representation"})
+    else
+      req
+    end
   end
 end

--- a/test/postgrestex_test.exs
+++ b/test/postgrestex_test.exs
@@ -30,6 +30,25 @@ defmodule PostgrestexTest do
     assert(resp.request.body =~ "nevergonna")
   end
 
+  test "create query returning" do
+    {:ok, resp} =
+      init("public")
+      |> from("users")
+      |> insert(
+        %{username: "new user", age_range: "[1,2)", status: "ONLINE", catchphrase: "giveyouup"},
+        false,
+        returning: true
+      )
+      |> call()
+
+    assert(resp.body =~ "new user")
+    assert(resp.status_code == 201)
+
+    on_exit(fn ->
+      init("public") |> from("users") |> delete() |> eq("username", "new user") |> call()
+    end)
+  end
+
   test "read query" do
     {:ok, %HTTPoison.Response{status_code: status_code, body: body}} =
       init("public") |> from("messages") |> select(["id", "username"]) |> call()

--- a/test/postgrestex_test.exs
+++ b/test/postgrestex_test.exs
@@ -31,8 +31,12 @@ defmodule PostgrestexTest do
   end
 
   test "read query" do
-    {:ok, resp} = init("public") |> from("messages") |> select(["id", "username"]) |> call()
-    assert(resp.status_code == 200)
+    {:ok, %HTTPoison.Response{status_code: status_code, body: body}} =
+      init("public") |> from("messages") |> select(["id", "username"]) |> call()
+
+    [row | _rest] = Jason.decode!(body, keys: :atoms)
+    assert(status_code == 200)
+    assert(Map.keys(row) |> Enum.sort() == [:id, :username])
   end
 
   test "multivalued params work" do

--- a/test/postgrestex_test.exs
+++ b/test/postgrestex_test.exs
@@ -67,6 +67,21 @@ defmodule PostgrestexTest do
     assert(resp.status_code == 204)
   end
 
+  test "delete returns row" do
+    {:ok, %HTTPoison.Response{status_code: status_code, body: body}} =
+      init("public")
+      |> from("users")
+      |> eq("username", "nevergonna")
+      |> delete(returning: true)
+      |> call()
+
+    assert(status_code == 200)
+    body = Jason.decode!(body, keys: :atoms)
+    assert(length(body) == 1)
+    [user] = body
+    assert(user.username == "nevergonna")
+  end
+
   test "update headers inserts a header" do
     assert(update_headers(init("api"), %{new_header: "header"}).headers.new_header == "header")
   end


### PR DESCRIPTION
While working with postgrest-ex I noticed a couple of issues, for example conditions passed to `select` were ignored.
This PR fixes this.

It also extends `delete` and `insert` so that it is possible to get the created/deleted item back if needed.